### PR TITLE
Fixes a bug where default properties were not editable

### DIFF
--- a/src/js/models/Rule.js
+++ b/src/js/models/Rule.js
@@ -53,7 +53,7 @@ export const RuleFactory = (values: $Shape<RuleRecord>): Rule => {
         return property.set('definition', definition);
       }
       if (definition.defaultProperty != null) {
-        return definition.defaultProperty;
+        return definition.defaultProperty.set('rule', rule);
       }
       return RulePropertyFactory({ rule, definition });
     })

--- a/src/js/models/__tests__/Rule.test.js
+++ b/src/js/models/__tests__/Rule.test.js
@@ -86,6 +86,21 @@ describe('RuleFactory', () => {
     expect(rule.properties.get('property2').selector).toEqual('.default');
   });
 
+  it('should be the rule of the defaultProperties from the definition', () => {
+    const rule: Rule = RuleFactory({
+      definition: RuleDefinitionFactory({
+        properties: Map({
+          property: RulePropertyDefinitionFactory({
+            defaultProperty: RulePropertyFactory({ selector: '.default' }),
+          }),
+        }),
+      }),
+    });
+
+    expect(rule.properties.get('property')).not.toBeUndefined();
+    expect(rule.properties.get('property').rule.guid).toEqual(rule.guid);
+  });
+
   it('should ignore property not present on the definition', () => {
     const rule: Rule = RuleFactory({
       definition: RuleDefinitionFactory({


### PR DESCRIPTION
The lack of the rule pointer was preventing the field from being edited on RuleStore