### PR TITLE
Add update notice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,29 @@
         }
       }
     },
+    "@octokit/rest": {
+      "version": "14.0.9",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-14.0.9.tgz",
+      "integrity": "sha512-irP9phKfTXEZIcW2R+VNCtGHZJrXMWmSYp6RRfFn4BtAqtDRXF5z9JxCEQlAhNBf6X1koNi5k49tIAAAEJNlVQ==",
+      "requires": {
+        "before-after-hook": "1.1.0",
+        "debug": "3.1.0",
+        "is-array-buffer": "1.0.0",
+        "is-stream": "1.1.0",
+        "lodash": "4.17.4",
+        "url-template": "2.0.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "@types/node": {
       "version": "7.0.46",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.46.tgz",
@@ -1268,6 +1291,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "before-after-hook": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
+      "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA=="
+    },
     "bin-version": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
@@ -1791,6 +1819,11 @@
       "requires": {
         "babel-runtime": "6.26.0"
       }
+    },
+    "compare-versions": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.1.0.tgz",
+      "integrity": "sha512-4hAxDSBypT/yp2ySFD346So6Ragw5xmBn/e/agIGl3bZr6DLUqnoRZPusxKrXdYRZpgexO9daejmIenlq/wrIQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -4770,6 +4803,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
+    },
+    "is-array-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-1.0.0.tgz",
+      "integrity": "sha512-KtzJzWuC1kZQ377GJbEsoBh0LuQh1uaZnQg8oL2LcDkY/Ny8rpAzu21Ls3oph3SEKXbnrLHt3rAUVm28iuEPfw=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -9117,6 +9155,11 @@
           "dev": true
         }
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "react"
   ],
   "dependencies": {
+    "@octokit/rest": "^14.0.9",
+    "compare-versions": "^3.1.0",
     "electron-debug": "^1.4.0",
     "electron-settings": "^3.1.4",
     "flux": "^3.1.3",

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -662,3 +662,7 @@ button {
 a:hover {
   cursor: pointer !important;
 }
+.update-notice .close {
+  margin-top: 4px !important;
+  margin-right: 5px !important;
+}

--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -17,6 +17,7 @@ import type { Props } from '../containers/AppContainer.react';
 import { NUX } from './NUX.react';
 import { NUXTour } from './NUXTour.react';
 import { BugReporter } from './BugReporter.react';
+import { UpdateNotice } from './UpdateNotice.react';
 
 class App extends React.Component<Props> {
   constructor(props: Props) {
@@ -76,6 +77,7 @@ class App extends React.Component<Props> {
             <RuleList {...this.props} />
           </nav>
         </div>
+        <UpdateNotice {...this.props} />
       </div>
     );
   }

--- a/src/js/components/UpdateNotice.react.js
+++ b/src/js/components/UpdateNotice.react.js
@@ -36,8 +36,11 @@ export class UpdateNotice extends React.Component<Props, State> {
       releaseVersion: null,
       visible: false,
     };
-    this.fetchVersion();
   }
+
+  componentDidMount = () => {
+    this.fetchVersion();
+  };
 
   handleDismiss = () => {
     this.setState({

--- a/src/js/components/UpdateNotice.react.js
+++ b/src/js/components/UpdateNotice.react.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React from 'react';
+import { Message, Icon, Transition } from 'semantic-ui-react';
+import type { Props } from '../containers/AppContainer.react';
+import { version } from '../version';
+import { shell } from 'electron';
+
+const compareVersions = require('compare-versions');
+const octokit = require('@octokit/rest')();
+
+const repository = {
+  owner: 'facebook',
+  repo: 'facebook-instant-articles-rules-editor',
+};
+
+type State = {
+  releaseURL: ?string,
+  releaseVersion: ?string,
+  visible: boolean
+};
+
+export class UpdateNotice extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      releaseURL: null,
+      releaseVersion: null,
+      visible: false,
+    };
+    this.fetchVersion();
+  }
+
+  handleDismiss = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  fetchVersion = () => {
+    octokit.repos.getLatestRelease(repository, (error, result) => {
+      if (result == null || result['data'] == null) {
+        return;
+      }
+      const data = result['data'];
+      const releaseURL = data['html_url'];
+      const releaseVersion = data['tag_name'];
+
+      if (releaseURL != null && releaseVersion != null) {
+        this.setState({
+          releaseURL,
+          releaseVersion,
+          visible: compareVersions(releaseVersion, version) > 0,
+        });
+      }
+    });
+  };
+
+  render() {
+    return (
+      <Transition.Group animation="slide up" duration={500}>
+        {this.state.visible && (
+          <Message
+            warning
+            attached="bottom"
+            onDismiss={this.handleDismiss}
+            className="update-notice"
+          >
+            <center>
+              <a
+                onClick={() => shell.openExternal(this.state.releaseURL)}
+                tabIndex="0"
+                role="button"
+              >
+                <Icon name="download" />
+                A new version ({this.state.releaseVersion}) is available, click
+                here to download it.
+              </a>
+            </center>
+          </Message>
+        )}
+      </Transition.Group>
+    );
+  }
+}


### PR DESCRIPTION
This PR:

- [x] Adds an update notice when the app is outdated.

<img width="1648" alt="update-notice" src="https://user-images.githubusercontent.com/1878108/36189150-caf7f8b2-1137-11e8-9f5a-94d311ef4a12.png">

### Test Plan

Simply load the App to see the message (I've created a faux release tagged 0.1.1 that is newer than the current version on version.js - I'll delete the release once this is merged).
- You should be able to dismiss it.
- Clicking on the message takes you to the release page.