### PR TITLE
App version tracking with FB Pixel

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -4,6 +4,20 @@
         <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.12/semantic.min.css"></link>
         <link rel="stylesheet" href="../../node_modules/react-joyride/lib/react-joyride-compiled.css" type="text/css">
         <link rel="stylesheet" type="text/css" href="../css/style.css" />
+        <!-- Facebook Pixel Code -->
+        <script>
+          !function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '178314219485164');
+          fbq('track', 'PageView');
+        </script>
+        <!-- End Facebook Pixel Code -->
     </head>
     <body>
         <div id="root">
@@ -11,6 +25,7 @@
         <script>
             require('babel-register');
             require('../../src/js/client');
+            require('../../src/js/utils/analytics');
         </script>
     </body>
 </html>

--- a/src/js/utils/analytics.js
+++ b/src/js/utils/analytics.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+const { app } = require('electron').remote;
+
+// Sending custom parameter to track the version of the app.
+// By default, the PageView event shows 'Unknown' as of March 11, 2018
+// eslint-disable-next-line no-undef
+fbq('trackCustom', 'AppInit', {
+  // Using Electron's getVersion to account for dev and packaged versions
+  version: app ? app.getVersion() : 'Unknown',
+});


### PR DESCRIPTION
This PR adds our team's pixel to track the usage of different versions of the app. I took the pixel default code and removed the `noscript` portion. We could move the Pixel ID to a config setting, but likely it is not a value that will change.

I am triggering a custom event `AppInit` to send the app version (which is read from the package.json file) because the `PageView` event that is logged by default does not contain the version (see screenshot below.) I added a script file for all analytics configuration, in case we want to track more actions.

For now, I think we should keep it simple. We can discuss in the future if we should also track buttons clicks and JS errors.