### PR TITLE
Mock some components during tests

### DIFF
--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -9,15 +9,15 @@
  */
 
 const React = require('react');
-const Browser = require('./Browser.react.js');
 const RuleList = require('./RuleList.react.js');
 const EditorActions = require('../data/EditorActions');
 
+import Browser from './Browser.react';
 import type { Props } from '../containers/AppContainer.react';
 import { NUX } from './NUX.react';
-import { NUXTour } from './NUXTour.react';
+import NUXTour from './NUXTour.react';
 import { BugReporter } from './BugReporter.react';
-import { UpdateNotice } from './UpdateNotice.react';
+import UpdateNotice from './UpdateNotice.react';
 
 class App extends React.Component<Props> {
   constructor(props: Props) {

--- a/src/js/components/NUXTour.react.js
+++ b/src/js/components/NUXTour.react.js
@@ -26,7 +26,7 @@ const importExportEncoding = 'utf8';
 const tutorialSite =
   'https://media.fb.com/2016/03/07/instant-articles-wordpress-plugin/';
 
-export class NUXTour extends React.Component<Props> {
+class NUXTour extends React.Component<Props> {
   joyride: ?Joyride = null;
 
   newConfiguration = () => {
@@ -530,3 +530,5 @@ export class NUXTour extends React.Component<Props> {
     );
   }
 }
+
+export default NUXTour;

--- a/src/js/components/UpdateNotice.react.js
+++ b/src/js/components/UpdateNotice.react.js
@@ -28,7 +28,7 @@ type State = {
   visible: boolean
 };
 
-export class UpdateNotice extends React.Component<Props, State> {
+class UpdateNotice extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -94,3 +94,5 @@ export class UpdateNotice extends React.Component<Props, State> {
     );
   }
 }
+
+export default UpdateNotice;

--- a/src/js/components/__mocks__/Browser.react.js
+++ b/src/js/components/__mocks__/Browser.react.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Mock component to be used for tests
+function Browser() {
+  return null;
+}
+
+export default Browser;

--- a/src/js/components/__mocks__/NUX.react.js
+++ b/src/js/components/__mocks__/NUX.react.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Mock component to be used for tests
+export function NUX() {
+  return null;
+}
+
+export default NUX;

--- a/src/js/components/__mocks__/NUXTour.react.js
+++ b/src/js/components/__mocks__/NUXTour.react.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Mock component to be used for tests
+function NUXTour() {
+  return null;
+}
+
+export default NUXTour;

--- a/src/js/components/__mocks__/UpdateNotice.react.js
+++ b/src/js/components/__mocks__/UpdateNotice.react.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// Mock component to be used for tests
+function UpdateNotice() {
+  return null;
+}
+
+export default UpdateNotice;

--- a/src/js/components/__tests__/RuleList.react-test.js
+++ b/src/js/components/__tests__/RuleList.react-test.js
@@ -9,6 +9,11 @@
 jest.mock('fs');
 const fs = require('fs');
 
+jest.mock('../Browser.react.js');
+jest.mock('../NUX.react.js');
+jest.mock('../NUXTour.react.js');
+jest.mock('../UpdateNotice.react.js');
+
 const Adapter = require('enzyme-adapter-react-15');
 const Enzyme = require('enzyme');
 const { mount } = Enzyme;


### PR DESCRIPTION
This PR adds mocks to some of the React components of the application, which do not need to be fully loaded for the existing tests.

The main driver of these changes is mocking the `UpdateNotice` component, which performs a web request once loaded. This was causing the tests to be slow.

I had to change some of the imports to make the mocks work.

![image](https://user-images.githubusercontent.com/18663703/37547713-be95a900-2949-11e8-8e7c-492f11681b9e.png)

Here is how it looks after these changes:

![image](https://user-images.githubusercontent.com/18663703/37547750-e41e8ee4-2949-11e8-8e5b-e36f695c7278.png)
