### PR TITLE
Include attribution info in the exported file

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -9,9 +9,19 @@
 // The file name that will always be returned as the one selected by the user
 const FILE_NAME = 'rules.json';
 
+// Variable to store the value returned by the getVersion function
+let version = '0.0.0';
+
 // Get a mock of the Electron module
 const electron = {
   remote: {
+    // Replace the function we will use in the app object
+    app: {
+      // We will return the value of the 'version' variable
+      getVersion: () => version,
+      // Mechanism to update the value of the 'version' variable
+      __setVersion: value => version = value,
+    },
     // Replace the function we will use in the dialog object
     dialog: {
       // Call directly the callback function passing a single valid file name

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "facebook-instant-articles-sdk-rules-editor",
-  "version": "0.0.1",
+  "name": "facebook-instant-articles-rules-editor",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "facebook-instant-articles-sdk-rules-editor",
+  "name": "facebook-instant-articles-rules-editor",
   "productName": "Facebook Instant Articles Rules Editor",
   "version": "0.2.0",
   "description": "App to help creating transformer rules for the Facebook Instant Articles SDK.",

--- a/src/js/components/__tests__/RuleList.react-test.js
+++ b/src/js/components/__tests__/RuleList.react-test.js
@@ -15,6 +15,11 @@ const { mount } = Enzyme;
 
 const React = require('react');
 
+const defaultAttributionInfo = {
+  generator_name: 'facebook-instant-articles-rules-editor',
+  generator_version: '0.0.0',
+};
+
 // Rules that are always included in the exported file
 const defaultExportedRules = [{ class: 'TextNodeRule' }];
 
@@ -34,10 +39,11 @@ describe('RuleList', () => {
     // Set this function as the one that will be called as fs.writeFile
     fs.__setWriteFileCallback((fileName, contents, encoding, errorCallback) => {
       // Expected exported object has no rules
-      const expectedRules = {
+      const expectedContents = {
+        ...defaultAttributionInfo,
         rules: [...defaultExportedRules],
       };
-      expect(JSON.parse(contents)).toEqual(expectedRules);
+      expect(JSON.parse(contents)).toEqual(expectedContents);
     });
 
     simlulateExport();
@@ -228,6 +234,7 @@ describe('RuleList', () => {
     inputRules.forEach(rule => RuleDefinitionActions.addRuleDefinition(rule));
 
     const importedFileObj = {
+      ...defaultAttributionInfo,
       rules: [
         ...defaultExportedRules,
         {

--- a/src/js/utils/RuleExporter.js
+++ b/src/js/utils/RuleExporter.js
@@ -9,6 +9,7 @@
  */
 
 import AdsTypes from '../data/AdsTypes';
+import { remote as ElectronRemote } from 'electron';
 import Immutable from 'immutable';
 import type { Rule } from '../models/Rule';
 import type { RuleProperty } from '../models/RuleProperty';
@@ -23,9 +24,13 @@ import { RuleUtils } from '../utils/RuleUtils';
 import { RulePropertyUtils } from '../utils/RulePropertyUtils';
 import SettingsActions from '../data/SettingsActions';
 
+const GENERATOR_NAME = 'facebook-instant-articles-rules-editor';
+
 export type JSONFormat = {
   ads?: { audience_network_placement_id?: string, raw_html?: string },
   analytics?: { fb_pixel_id?: string, raw_html?: string },
+  generator_name: string,
+  generator_version: string,
   rules: RuleJSON[],
   style_name?: string
 };
@@ -127,6 +132,11 @@ class RuleExporter {
     settings: TransformationSettings
   ): JSONFormat {
     let exported = {
+      // We are NOT using ElectronRemote.app.getName() because it defaults to
+      // the 'productName' field in the package.json file
+      // (Facebook Instant Articles Rules Editor) and we are looking for 'name'
+      generator_name: GENERATOR_NAME,
+      generator_version: ElectronRemote.app.getVersion(),
       rules: [
         { class: 'TextNodeRule' },
         ...Array.from(

--- a/src/js/utils/__tests__/RuleExporter.test.js
+++ b/src/js/utils/__tests__/RuleExporter.test.js
@@ -8,6 +8,7 @@
 
 import { Map, Set } from 'immutable';
 import AdsTypes from '../../data/AdsTypes';
+import { remote as ElectronRemote } from 'electron';
 import RulesEditorDispatcher from '../../data/RulesEditorDispatcher';
 import RuleExporter from '../RuleExporter';
 import { RuleFactory } from '../../models/Rule';
@@ -88,6 +89,31 @@ describe('RuleExporter', () => {
         },
       },
     ]);
+  });
+
+  describe('Attribution', () => {
+    it('should set the generator name', () => {
+      // Fixed value
+      const expectedName = 'facebook-instant-articles-rules-editor';
+
+      const exported = RuleExporter.export(Map());
+
+      // Ensure the expected fixed value is returned
+      expect(exported.generator_name).toEqual(expectedName);
+    });
+
+    it('should set the generator version', () => {
+      // Generate random version name
+      const version = 'v' + Math.random().toString();
+      const { app } = ElectronRemote;
+      // Override the version with our random value
+      app.__setVersion(version);
+
+      const exported = RuleExporter.export(Map());
+
+      // Ensure we are calling app.getVersion()
+      expect(exported.generator_version).toEqual(version);
+    });
   });
 
   describe('Settings', () => {


### PR DESCRIPTION
This PR adds attribution info to the exported file, in the form of two new fields `generator_name` and `generator_version`.

Here is a summary of the changes:
- Updated the package name to match the name of the repo
- Added to the fields to the object returned at `RuleExporter.export`
  - The version is retrieved using Electron's `app.getVersion()`
  - The name is NOT coming from Electron's `app.getName()` because it defaults to the user-friendly field in `productName`.
- Moved the existing `electron` mock to the global mocks folder, so the same object is used by all tests (otherwise jest will detect a duplicated mock and will pick only one of them)
- Fixed existing unit tests to account for the two new attribution fields in the JSON file
- Added new unit tests to validate the presence of the two new fields in the JSON file